### PR TITLE
feat: add project potentiel solaire to the swarm

### DIFF
--- a/playbooks/swarm-production.yml
+++ b/playbooks/swarm-production.yml
@@ -185,6 +185,15 @@
         - service
 
     - import_role:
+        name: roles/services/d4g-13-potentiel-solaire
+      vars:
+        deploy_on: "metal-1.dataforgood.fr"
+        replicas: 1
+      tags:
+        - d4g-13-potentiel-solaire
+        - service
+
+    - import_role:
         name: roles/utilities/traefik
       vars:
         base_domain: services.dataforgood.fr
@@ -219,6 +228,8 @@
             addresses: ["d4g-authentik_app"]
           - name: "us-climate-data"
             addresses: ["us-climate-data-metabase_app:3000"]
+          - name: "d4g-13-potentiel-solaire"
+            addresses: ["d4g-13-potentiel-solaire_app:3000"]
       tags:
         - proxy
         - traefik

--- a/roles/services/d4g-13-potentiel-solaire/tasks/main.yml
+++ b/roles/services/d4g-13-potentiel-solaire/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Create d4g-13-potentiel-solaire directory
+  file:
+    path: /opt/d4g-13-potentiel-solaire
+    state: directory
+
+- name: Creating d4g-13-potentiel-solaire template
+  template:
+    src: "docker-compose.yml.j2"
+    dest: /opt/d4g-13-potentiel-solaire/docker-compose.yml
+
+- name: Pull
+  command: docker compose pull
+  args:
+    chdir: /opt/d4g-13-potentiel-solaire
+  tags:
+    - pull
+  when: inventory_hostname == deploy_on
+
+- name: Up
+  command: docker stack deploy -c docker-compose.yml d4g-13-potentiel-solaire
+  args:
+    chdir: /opt/d4g-13-potentiel-solaire
+  tags:
+    - up
+  when: is_swarm_leader | default(false)

--- a/roles/services/d4g-13-potentiel-solaire/templates/docker-compose.yml.j2
+++ b/roles/services/d4g-13-potentiel-solaire/templates/docker-compose.yml.j2
@@ -1,0 +1,14 @@
+services:
+  app:
+    image: ghcr.io/dataforgoodfr/13_potentiel_solaire_app:latest
+    networks:
+      - d4g-internal
+    deploy:
+      replicas: {{ replicas }}
+      placement:
+        constraints:
+          - node.hostname == {{ deploy_on }}
+
+networks:
+  d4g-internal:
+    external: true


### PR DESCRIPTION
Ajout du projet potentiel solaire au swarm docker.
Le docker ne nécessite pas de variable d'environnement, le port exposé est le 3000.