### PR TITLE
[FIX]: Missing env variables for Website service

### DIFF
--- a/roles/services/d4g-website/templates/website.env.j2
+++ b/roles/services/d4g-website/templates/website.env.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 NODE_ENV=production
-STRAPI_URL={{ lookup('env', 'STRAPI_URL') }}
+STRAPI_API_URL={{ lookup('env', 'STRAPI_API_URL') }}
+STRAPI_API_TOKEN={{ lookup('env', 'STRAPI_API_TOKEN') }}


### PR DESCRIPTION
Update website.env template to use missing Strapi vars