### PR TITLE
fix: (13_potentiel_solaire) add missing env template to generation task

### DIFF
--- a/roles/services/d4g-13-potentiel-solaire/tasks/main.yml
+++ b/roles/services/d4g-13-potentiel-solaire/tasks/main.yml
@@ -4,10 +4,13 @@
     path: /opt/d4g-13-potentiel-solaire
     state: directory
 
-- name: Creating d4g-13-potentiel-solaire template
+- name: Create d4g-13-potentiel-solaire files
   template:
-    src: "docker-compose.yml.j2"
-    dest: /opt/d4g-13-potentiel-solaire/docker-compose.yml
+    src: "{{ item }}.j2"
+    dest: /opt/d4g-13-potentiel-solaire/{{ item }}
+  with_items:
+    - docker-compose.yml
+    - 13_potentiel_solaire.env
 
 - name: Pull
   command: docker compose pull


### PR DESCRIPTION
Il manquait la spécification du fichier .env template à la tâche de génération des fichiers du service 13_potentiel_solaire (voir #25)