### PR TITLE
[democis] Corrige le scroll horizontal sur mobile et clarifie les contacts du footer

### DIFF
--- a/roles/services/democis/files/index.html
+++ b/roles/services/democis/files/index.html
@@ -1041,6 +1041,18 @@ p.lead {
   transition: color 0.2s;
 }
 .footer-col ul li a:hover { color: var(--rouge); }
+/* Sous-titre « Contact presse » : même traitement que les h4 du footer,
+   pour distinguer l'adresse presse de l'adresse de contact générale. */
+.footer-contact-role { margin-top: 24px; }
+.footer-contact-role > span {
+  display: block;
+  font-family: var(--font-tech);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.55);
+  margin-bottom: 10px;
+}
 /* Le <wbr> des adresses mail n'est utile qu'en mono-colonne : neutralisé ici,
    sinon il casse l'adresse en deux lignes alors qu'elle tient sur une. */
 .footer-col ul li a wbr { display: none; }
@@ -1559,8 +1571,10 @@ p.lead {
       <ul>
         <!-- <wbr> : point de césure privilégié après le @, pour éviter une coupure au milieu du domaine -->
         <li><a href="mailto:contact@conventioncitoyennepourlademocratie.fr">contact@<wbr>conventioncitoyennepourlademocratie.fr</a></li>
-        <li><a href="mailto:oteixeira@bonafide.paris">oteixeira@<wbr>bonafide.paris</a></li>
-        <li><a href="mailto:relationspresse@univ-lille.fr">relationspresse@<wbr>univ-lille.fr</a></li>
+        <li class="footer-contact-role">
+          <span>Contact presse</span>
+          <a href="mailto:oteixeira@bonafide.paris">oteixeira@<wbr>bonafide.paris</a>
+        </li>
       </ul>
     </div>
   </div>

--- a/roles/services/democis/files/index.html
+++ b/roles/services/democis/files/index.html
@@ -508,7 +508,9 @@ p.lead {
   background: var(--blanc);
   padding: 36px 40px;
   display: grid;
-  grid-template-columns: clamp(96px, 11vw, 130px) 1fr;
+  /* minmax(0,…) : sans ça le min-width:auto de la piste vaut la largeur du
+     mot le plus long (« socio-démographiques. ») et élargit la carte. */
+  grid-template-columns: clamp(96px, 11vw, 130px) minmax(0, 1fr);
   gap: 32px;
   align-items: center;
   transition: transform 0.3s var(--ease), box-shadow 0.3s var(--ease);
@@ -538,10 +540,18 @@ p.lead {
   line-height: 1.5;
   color: var(--encre-doux);
 }
+.panel-card-label,
+.panel-card-desc { overflow-wrap: break-word; }
 
 @media (max-width: 880px) {
   .panel-grid { grid-template-columns: 1fr; gap: 48px; }
   .panel-card { padding: 28px 24px; gap: 20px; }
+}
+@media (max-width: 480px) {
+  /* Sur très petits écrans, le chiffre passe au-dessus du texte :
+     côte à côte il ne reste plus assez de place pour le libellé. */
+  .panel-card { grid-template-columns: 1fr; gap: 12px; }
+  .panel-card-num { text-align: left; }
 }
 
 /* =========================================================================
@@ -835,9 +845,13 @@ p.lead {
   padding: 6px;
   align-items: center;
   gap: 0;
+  flex-wrap: wrap;
 }
 .newsletter-input input {
   flex: 1;
+  /* Sans min-width:0 l'input refuse de descendre sous sa taille intrinsèque :
+     la ligne reste plus large que l'écran et le bouton sort du cadre. */
+  min-width: 0;
   border: none;
   background: transparent;
   padding: 18px 20px;
@@ -893,6 +907,12 @@ p.lead {
 .newsletter-social a:hover { border-bottom-color: var(--blanc); opacity: 0.85; }
 @media (max-width: 880px) {
   .newsletter-grid { grid-template-columns: 1fr; gap: 32px; }
+}
+@media (max-width: 480px) {
+  /* Sous ~432px le bouton sortait du cadre : champ et bouton sont empilés,
+     côte à côte il ne reste plus assez de place pour saisir une adresse. */
+  .newsletter-input { flex-direction: column; align-items: stretch; gap: 6px; }
+  .newsletter-input button { width: 100%; }
 }
 
 .sib-form-message-panel {
@@ -1021,6 +1041,9 @@ p.lead {
   transition: color 0.2s;
 }
 .footer-col ul li a:hover { color: var(--rouge); }
+/* Le <wbr> des adresses mail n'est utile qu'en mono-colonne : neutralisé ici,
+   sinon il casse l'adresse en deux lignes alors qu'elle tient sur une. */
+.footer-col ul li a wbr { display: none; }
 .footer-bottom {
   max-width: var(--max-width);
   margin: 0 auto;
@@ -1046,6 +1069,22 @@ p.lead {
 @media (max-width: 880px) {
   .footer-grid { grid-template-columns: 1fr 1fr; gap: 40px; }
   .footer-brand { grid-column: 1 / -1; }
+}
+@media (max-width: 560px) {
+  /* Une seule colonne : sur deux colonnes il ne reste qu'environ 150px,
+     trop peu pour afficher les adresses mail sans les hacher. */
+  .footer-grid { grid-template-columns: 1fr; gap: 36px; }
+  /* Ces deux règles ne valent que sous 560px. Au-dessus, c'est la largeur
+     min-content des adresses mail qui dimensionne la colonne Contact et les
+     garde sur une seule ligne : y toucher décalerait le footer en desktop. */
+  .footer-col { min-width: 0; }
+  .footer-col ul li a {
+    display: inline-block;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+  /* Réactivé : la césure se fera après le @ plutôt qu'au milieu du domaine. */
+  .footer-col ul li a wbr { display: inline; }
 }
 
 /* =========================================================================
@@ -1518,9 +1557,10 @@ p.lead {
     <div class="footer-col">
       <h4>Contact</h4>
       <ul>
-        <li><a href="mailto:contact@conventioncitoyennepourlademocratie.fr">contact@conventioncitoyennepourlademocratie.fr</a></li>
-        <li><a href="mailto:oteixeira@bonafide.paris">oteixeira@bonafide.paris</a></li>
-        <li><a href="mailto:relationspresse@univ-lille.fr">relationspresse@univ-lille.fr</a></li>
+        <!-- <wbr> : point de césure privilégié après le @, pour éviter une coupure au milieu du domaine -->
+        <li><a href="mailto:contact@conventioncitoyennepourlademocratie.fr">contact@<wbr>conventioncitoyennepourlademocratie.fr</a></li>
+        <li><a href="mailto:oteixeira@bonafide.paris">oteixeira@<wbr>bonafide.paris</a></li>
+        <li><a href="mailto:relationspresse@univ-lille.fr">relationspresse@<wbr>univ-lille.fr</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Deux modifications sur le site statique de la Convention Citoyenne pour la Démocratie (`roles/services/democis/files/index.html`). Aucun changement côté Ansible ou docker-compose.

## 1. Scroll horizontal sur mobile (fix)

Signalé sur Android : la page défilait latéralement et le bouton « Suivre » sortait de l'écran.

**Cause.** L'adresse `contact@conventioncitoyennepourlademocratie.fr` (45 caractères) n'offre aucun point de césure. Sa largeur `min-content` servait de plancher à la colonne de grille du footer, ce qui forçait la page à **521px de large quelle que soit la taille de l'écran**. Le `<nav>` étant en `position: fixed` sur toute la largeur du document, il s'étirait d'autant et le bouton « Suivre », aligné à sa droite, se retrouvait hors du viewport — d'où l'impression qu'il était en cause alors qu'il n'était que le symptôme le plus visible.

| Viewport | `scrollWidth` avant | après |
|---|---|---|
| 320 → 480px | **521px** (débordement de 41 à 201px) | = viewport |
| 540px et + | = viewport | = viewport |

Le seuil à 540px explique que le bug soit passé inaperçu : aucune fenêtre de bureau n'est assez étroite pour le déclencher.

**Deux débordements masqués corrigés au passage :**

- La ligne champ + bouton de la newsletter mesurait 384px et débordait sous ~432px de viewport. L'`overflow: hidden` de la section masquait le problème : pas de scroll, mais une partie du bouton « Je m'inscris » **invisible et incliquable** sur un écran de 360px. Champ et bouton sont désormais empilés sous 480px.
- La piste `1fr` des cartes du panel avait pour plancher la largeur de « socio-démographiques. », ce qui faisait déborder la carte à 320px.

**Non-régression.** Les règles correctives sont confinées aux media queries mobiles. Le rendu desktop et tablette a été vérifié pixel à pixel contre `main` par comparaison des rendus pleine page : identique. Absence de débordement vérifiée sur 16 largeurs de 320 à 1600px (`scrollWidth == viewport` et `scrollX` max nul partout).

## 2. Contacts du footer

- `contact@conventioncitoyennepourlademocratie.fr` devient la seule adresse de contact général.
- `oteixeira@bonafide.paris` est explicitement identifiée comme contact presse, sous un sous-titre reprenant la typographie des intitulés de colonne du footer.
- `relationspresse@univ-lille.fr` est retirée.

## Point ouvert pour les relecteurs

Sous 480px, le chiffre des cartes du panel passe **au-dessus** du texte au lieu d'être à gauche. C'est nécessaire à 320px pour éliminer le débordement, mais entre 360 et 480px c'est un choix de lisibilité qui va au-delà de la stricte correction. Facile à restreindre à un seuil plus bas si vous préférez conserver la disposition actuelle sur cette plage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)